### PR TITLE
Only display date rather than date & specific time

### DIFF
--- a/chessbot/cogs/utils/status_utils.py
+++ b/chessbot/cogs/utils/status_utils.py
@@ -70,7 +70,7 @@ def get_game_status(bot: commands.Bot, game: database.Game) -> Tuple[str, discor
                 f"If {opposite_side_str} wants to accept, they should type *{bot.command_prefix}accept {game.id}*\n"
             )
 
-        status += f"\nThis game will expire on {game.expiration_date},\nresulting in {turn_str} losing, if they don't make a move.\n"
+        status += f"\nThis game will expire on {str(game.expiration_date).split()[0]},\nresulting in {turn_str} losing, if they don't make a move.\n"
 
     elif game.winner is not None and game.win_reason is not None:
         result = constants.turn_to_str(game.winner).capitalize()


### PR DESCRIPTION
Switch to only displaying the date rather than including a specific time without the timezone being specified. This improves the bot's aesthetics.